### PR TITLE
Changing CAN RTR condition

### DIFF
--- a/Source_codes/STM32CubeIDE/MasteringMCU2/CAN_Normal_Mode_2Nodes/Core/Src/main_app.c
+++ b/Source_codes/STM32CubeIDE/MasteringMCU2/CAN_Normal_Mode_2Nodes/Core/Src/main_app.c
@@ -348,7 +348,7 @@ void HAL_CAN_TxMailbox2CompleteCallback(CAN_HandleTypeDef *hcan)
 		LED_Manage_Output(rcvd_msg[0]);
 		sprintf(msg,"Message Received : #%x\r\n",rcvd_msg[0]);
 	}
-	else if ( RxHeader.StdId == 0x651 && RxHeader.RTR == 1)
+	else if ( RxHeader.StdId == 0x651 && RxHeader.RTR == 2)
 	{
 		//This is a remote frame sent by n1 to n2
 		Send_response(RxHeader.StdId);


### PR DESCRIPTION
HAL_CAN_GetRxMessage(CAN_HandleTypeDef *hcan, uint32_t RxFifo, CAN_RxHeaderTypeDef *pHeader, uint8_t aData[]) RTR is assigned as following:

pHeader->RTR = (CAN_RI0R_RTR & hcan->Instance->sFIFOMailBox[RxFifo].RIR);

while, CAN_RI0R_RTR = 0x1UL << 1UL
Therefore if RTR in RIR register is set, the resulting value stored in pHeader->RTR evaluates to 2.